### PR TITLE
Adds README and initialises trunk

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,7 @@
+*out
+*logs
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/config/.markdownlint.yaml
+++ b/.trunk/config/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+cli:
+  version: 1.1.0
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.6
+      uri: https://github.com/trunk-io/plugins
+lint:
+  enabled:
+    - markdownlint@0.32.2
+    - prettier@2.7.1
+    - git-diff-check
+    - gitleaks@8.11.2
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
+actions:
+  enabled:
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
+    - trunk-upgrade-available

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# .github
+# Conduit
+
+The public organization `README` for Conduit.
+
+Utilizes [Community Health Files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) to ensure a consistent `.github` repository across the organization.


### PR DESCRIPTION
## 💬 Description 

Github defines a `.github` repository as a [Community Health Repository](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file). Currently, the intention is to utilise this as a mechanism to share a common `PULL_REQUEST_TEMPLATE` across the organisation.

Note: Due to Github constraints, this is a public repository.
